### PR TITLE
Patch 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
 	<script type="text/javascript" src="https://w.sharethis.com/button/buttons.js"></script>
 	<script type="text/javascript">stLight.options({publisher: "505a26ad-d820-47bd-a500-7f49d04a30f5", doNotHash: true, doNotCopy: false, hashAddressBar: false});</script>
 	</head>
-<body onload="checksize();">
+<body onload="checksize();loadLS();">
 	
 	<a id="pngdownload" href="" download="Sankey.png" style="visibility:hidden;display:none;position:fixed;top:0px;left:0px;width:0px;height:0px;" target="_blank"></a>
 

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
 	<script type="text/javascript" src="https://w.sharethis.com/button/buttons.js"></script>
 	<script type="text/javascript">stLight.options({publisher: "505a26ad-d820-47bd-a500-7f49d04a30f5", doNotHash: true, doNotCopy: false, hashAddressBar: false});</script>
 	</head>
-<body onload="checksize();loadLS();">
+<body onload="checksize();">
 	
 	<a id="pngdownload" href="" download="Sankey.png" style="visibility:hidden;display:none;position:fixed;top:0px;left:0px;width:0px;height:0px;" target="_blank"></a>
 

--- a/js/food.js
+++ b/js/food.js
@@ -34,7 +34,7 @@ function removelink() {
 	linksform[0][0].children[linksform[0][0].children.length-1].remove("div")
 }
 function draw() {
-	
+	saveLS()
 	data={"nodes": [], "links": []}
 	
 	for (i = 0; i < nodesform[0][0].children.length; i++) {
@@ -47,7 +47,19 @@ function draw() {
 }
 function save(){
 	d3.select('#save').style('z-index',100).transition().style('opacity',0.9);
-	st='{"sankey":{"nodes":['
+	st=generateJSON();
+	d3.select('#savetext').text(st);
+}
+function saveLS(){
+	if (typeof(Storage) !== "undefined") {
+    	// Code for localStorage
+		window.localStorage.setItem('rawtext',generateJSON());
+    	} else {
+    	// No web storage Support.
+	}
+}
+function generateJSON(){
+	var st='{"sankey":{"nodes":['
 	for (i = 0; i < nodesform[0][0].children.length; i++) {
 		st=st+nodesform[0][0].children[i].children[0].value+',';
 	}
@@ -64,7 +76,7 @@ function save(){
 		st=st+',"fixedlayout":'+JSON.stringify(coords);
 	} 
 	st=st+'}';
-	d3.select('#savetext').text(st);
+	return st;
 }
 function load(){
 	d3.select('#load').style('z-index',100).transition().style('opacity',0.9);
@@ -73,7 +85,23 @@ function loadsubmit(){
 	d3.select('#load').transition().style('opacity',0).style('z-index',-1);
 	var rawtext=d3.select('#load')[0][0].children[1].value;
 	if (rawtext!="") {
-		//parse data
+		loadraw(rawtext);
+	}
+}
+function loadLS(){
+	if (typeof(Storage) !== "undefined") {
+    	// Code for localStorage
+		if (window.localStorage.getItem("rawtext") === null) {
+		  //Nothing stored
+		} else {
+		loadraw(window.localStorage.getItem('rawtext'));
+		}
+    	} else {
+    	// No web storage Support.
+	}
+}
+function loadraw(rawtext){
+	//parse data
 		var rawdata=JSON.parse(rawtext);
 		if ("sankey" in rawdata) {
 			var newdata=rawdata.sankey;
@@ -124,7 +152,6 @@ function loadsubmit(){
 		else { 
 			change(newdata);
 		}
-	}
 }
 
 //<!--SANKEY DIAGRAM-->

--- a/js/food.js
+++ b/js/food.js
@@ -332,6 +332,8 @@ change = function(d) {
 		e.attr("d", path(2))
 	};
 };
+// check if there is any info stored in LocalStorage before first draw
+loadLS();
 draw();
 
 //<!-- SAVE FUNCTION-->


### PR DESCRIPTION
Fixes #18  
This also means you can now resize the window without losing your data.

Caveat: it does not save layout unless the save layout box is checked but the state of that box does not survive a page reload, this leads to some strange behaviour, such as on a large page, if you press "save layout" then save the data, when you resize down the diagram will stay large and be obscured. if you reload, the layout will not have been saved so it will the fit.

I think on balance not losing your work when resizing the window is better than the new strange behaviours introduced!
If you want to fix the save layout issue you will have to look at how to persist the state of the "save layout" tick box, it is not currently in your Params but it could be added. I'm not sure you want to go down that route as it would make it less easy to "shrink" the diagram.